### PR TITLE
Remove installing options for Homebrew

### DIFF
--- a/install-deps
+++ b/install-deps
@@ -95,7 +95,7 @@ if [[ `uname` == 'Darwin' ]]; then
     brew link readline --force
     brew cask install xquartz
     brew list -1 | grep -q "^gnuplot\$" && brew remove gnuplot
-    brew install gnuplot --with-wxmac --with-cairo --with-pdflib-lite --with-x11 --without-lua
+    brew install gnuplot
     brew install qt || true
 
 elif [[ "$(uname)" == 'Linux' ]]; then


### PR DESCRIPTION
Since installing options have been removed from gnuplot in Homebrew, we should also remove those in install-deps. 
See also: [Remove all options from Homebrew/homebrew-core formulae](https://github.com/Homebrew/homebrew-core/issues/31510)